### PR TITLE
fix(electron): 修复开发环境下的本地主机地址配置问题

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -91,6 +91,7 @@ export default defineConfig(({ mode }) => {
         },
       },
       server: {
+        host: "127.0.0.1",
         port: webPort,
         // 代理
         proxy: {
@@ -102,6 +103,7 @@ export default defineConfig(({ mode }) => {
         },
       },
       preview: {
+        host: "127.0.0.1",
         port: webPort,
       },
       build: {

--- a/electron/main/utils/config.ts
+++ b/electron/main/utils/config.ts
@@ -32,6 +32,11 @@ export const appName = app.getName() || "SPlayer";
  */
 export const port = Number(import.meta.env["VITE_SERVER_PORT"] || 25884);
 
+const devRendererUrl = process.env["ELECTRON_RENDERER_URL"]?.replace(
+  "://localhost",
+  "://127.0.0.1",
+);
+
 /**
  * 默认 AMLL TTML DB Server
  * @returns string
@@ -43,24 +48,22 @@ export const defaultAMLLDbServer = "https://amlldb.bikonoo.com/ncm-lyrics/%s.ttm
  * @returns string
  */
 export const mainWinUrl =
-  isDev && process.env["ELECTRON_RENDERER_URL"]
-    ? process.env["ELECTRON_RENDERER_URL"]
-    : `http://localhost:${port}`;
+  isDev && devRendererUrl ? devRendererUrl : `http://127.0.0.1:${port}`;
 
 /**
  * 歌词窗口加载地址
  * @returns string
  */
 export const lyricWinUrl =
-  isDev && process.env["ELECTRON_RENDERER_URL"]
-    ? `${process.env["ELECTRON_RENDERER_URL"]}/#/desktop-lyric`
-    : `http://localhost:${port}/#/desktop-lyric`;
+  isDev && devRendererUrl
+    ? `${devRendererUrl}/#/desktop-lyric`
+    : `http://127.0.0.1:${port}/#/desktop-lyric`;
 
 /**
  * 加载窗口地址
  * @returns string
  */
 export const loadWinUrl =
-  isDev && process.env["ELECTRON_RENDERER_URL"]
-    ? `${process.env["ELECTRON_RENDERER_URL"]}/web/loading/index.html`
-    : `http://localhost:${port}/web/loading/index.html`;
+  isDev && devRendererUrl
+    ? `${devRendererUrl}/web/loading/index.html`
+    : `http://127.0.0.1:${port}/web/loading/index.html`;


### PR DESCRIPTION
- 将 localhost 替换为 127.0.0.1 以解决网络连接问题
- 统一所有窗口 URL 配置中的地址引用
- 在 Vite 配置中设置服务器主机地址为 127.0.0.1
- 创建专门的 devRendererUrl 变量处理开发环境渲染器地址
- 确保歌词窗口和加载窗口使用正确的本地地址
- 修复了 ELECTRON_RENDERER_URL 环境变量的地址替换逻辑