### PR TITLE
fix: 修复滞后加载状态覆盖桌面歌词的问题

### DIFF
--- a/src/core/player/PlayerController.ts
+++ b/src/core/player/PlayerController.ts
@@ -211,7 +211,13 @@ class PlayerController {
     // 通知桌面歌词
     if (isElectron) {
       window.electron.ipcRenderer.send("desktop-lyric:update-data", {
+        currentTime: startSeek,
         lyricLoading: true,
+        songId: song.id,
+        songOffset: statusStore.getSongOffset(song.id),
+        lrcData: [],
+        yrcData: [],
+        lyricIndex: -1,
       });
     }
     // 更新任务栏歌词窗口的元数据

--- a/src/utils/initIpc.ts
+++ b/src/utils/initIpc.ts
@@ -85,7 +85,7 @@ const initIpc = () => {
     );
 
     // 给任务栏歌词初始数据
-window.electron.ipcRenderer.on(TASKBAR_IPC_CHANNELS.REQUEST_DATA, async () => {
+    window.electron.ipcRenderer.on(TASKBAR_IPC_CHANNELS.REQUEST_DATA, async () => {
       const musicStore = useMusicStore();
       const statusStore = useStatusStore();
 
@@ -140,6 +140,9 @@ window.electron.ipcRenderer.on(TASKBAR_IPC_CHANNELS.REQUEST_DATA, async () => {
       const statusStore = useStatusStore();
       if (player) {
         const { name, artist } = getPlayerInfoObj() || {};
+        const songLyric = statusStore.lyricLoading
+          ? { lrcData: [], yrcData: [] }
+          : toRaw(musicStore.songLyric);
         window.electron.ipcRenderer.send(
           "desktop-lyric:update-data",
           cloneDeep({
@@ -149,8 +152,8 @@ window.electron.ipcRenderer.on(TASKBAR_IPC_CHANNELS.REQUEST_DATA, async () => {
             currentTime: statusStore.currentTime,
             songId: musicStore.playSong?.id,
             songOffset: statusStore.getSongOffset(musicStore.playSong?.id),
-            lrcData: musicStore.songLyric.lrcData ?? [],
-            yrcData: musicStore.songLyric.yrcData ?? [],
+            lrcData: songLyric.lrcData ?? [],
+            yrcData: songLyric.yrcData ?? [],
             lyricIndex: statusStore.lyricIndex,
             lyricLoading: statusStore.lyricLoading,
           }),

--- a/src/views/DesktopLyric/index.vue
+++ b/src/views/DesktopLyric/index.vue
@@ -182,6 +182,15 @@ const lyricData = reactive<LyricData>({
   lyricIndex: -1,
 });
 
+const hasLyricLines = (data: Pick<LyricData, "lrcData" | "yrcData">) =>
+  Boolean(data.lrcData?.length || data.yrcData?.length);
+
+const shouldIgnoreLoadingUpdate = (data: LyricData) => {
+  if (data.lyricLoading !== true) return false;
+  if (hasLyricLines(data) || !hasLyricLines(lyricData)) return false;
+  return data.songId === undefined || data.songId === lyricData.songId;
+};
+
 // 锚点时间（毫秒）与锚点帧时间，用于插值推进
 let baseMs = 0;
 let anchorTick = 0;
@@ -306,7 +315,7 @@ const renderLyricLines = computed<RenderLine[]>(() => {
     return placeholder("SPlayer Desktop Lyric");
   }
   // 加载中
-  if (lyricData.lyricLoading) return placeholder("歌词加载中...");
+  if (lyricData.lyricLoading && !lyrics?.length) return placeholder("歌词加载中...");
   // 纯音乐
   if (!lyrics?.length) return placeholder("纯音乐，请欣赏");
   // 获取当前歌词索引
@@ -708,6 +717,12 @@ onMounted(() => {
   window.electron.ipcRenderer.on(
     "desktop-lyric:update-data",
     (_event, data: LyricData & { sendTimestamp?: number }) => {
+      if (shouldIgnoreLoadingUpdate(data)) {
+        if (isInitializing.value) {
+          isInitializing.value = false;
+        }
+        return;
+      }
       Object.assign(lyricData, data);
       // 首次接收到歌词数据时，立即结束初始化状态
       if (isInitializing.value) {


### PR DESCRIPTION
## 修复内容

修复桌面歌词在歌词已经正常加载后，又被滞后的加载状态或空歌词数据覆盖的问题。

这个问题会导致桌面歌词从正常歌词变成“歌词加载中...”或“纯音乐，请欣赏”。

## 主要改动

- 切歌进入歌词加载状态时，同步传递当前歌曲 ID 和空歌词数据。
- 桌面歌词请求数据时，避免把旧歌词和新的加载状态混在一起。
- 桌面歌词窗口在已有有效歌词时，忽略同一首歌的滞后空歌词加载更新。
- 已本地复现并验证修复桌面歌词显示问题；同时 fork Actions 构建通过。

- 
<img width="1729" height="895" alt="image" src="https://github.com/user-attachments/assets/4660b4f7-9b31-4f80-8563-6d77358d57b9" />
