### PR TITLE
fix: restore main window on macOS activation

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -122,6 +122,11 @@ class MainProcess {
 
     // 应用被激活
     app.on("activate", () => {
+      if (isMac) {
+        mainWindow.showWindow();
+        return;
+      }
+
       const allWindows = BrowserWindow.getAllWindows();
       if (allWindows.length) {
         allWindows[0].focus();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,19 @@ export default [
     },
   },
   {
+    files: [".github/scripts/prepare-release-assets.cjs"],
+
+    languageOptions: {
+      globals: { ...globals.node },
+      ecmaVersion: 5,
+      sourceType: "commonjs",
+    },
+
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+  {
     files: ["**/.eslintrc.{js,cjs}"],
 
     languageOptions: {


### PR DESCRIPTION
## 修复内容

修复 macOS 上关闭主窗口后，如果状态栏图标被系统隐藏，点击 Dock 图标无法重新呼出主页面的问题。

## 主要改动

- 在 macOS `activate` 事件中调用已有的 `mainWindow.showWindow()`，显式显示并聚焦主窗口。
- 保留非 macOS 平台原有的 `activate` 兜底逻辑，避免影响其他平台行为。
- 针对现有 CommonJS release 脚本补充精确 lint 规则豁免，保证 `pnpm lint` 可通过。

## 测试

- `pnpm format`
- `pnpm lint`
- `pnpm build`
- 已在 macOS 上人工测试：点击 Dock 栏图标可以正确打开主页面。

Fixes #1097
